### PR TITLE
Add v7.9.2 builds for additional platforms

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libpqxx" %}
-{% set version = "7.10.1" %}
+{% set version = "7.9.2" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/jtv/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: cfbbb1d93a0a3d81319ec71d9a3db80447bb033c4f6cee088554a88862fd77d7
+  sha256: e37d5774c39f6c802e32d7f418e88b8e530404fb54758516e884fc0ebdee6da4
 
 build:
-  number: 0
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 


### PR DESCRIPTION
This pull request includes a version downgrade and checksum update for the `libpqxx` package in the `recipe/meta.yaml` file.

### Package version and build changes:

* Downgraded `libpqxx` package version from `7.10.1` to `7.9.2`.
* Updated the SHA256 checksum to match the new version's source archive.
* Incremented the build number from `0` to `2`.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
